### PR TITLE
Add rich text description to lesson model and fix form alignment

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -6,6 +6,7 @@ class Lesson < ApplicationRecord
 
   acts_as_list
   has_many :lesson_users, dependent: :destroy
+  has_rich_text :description
 
   def next_lesson
     course.lessons.where("position > ?", position).order(:position).first

--- a/app/views/admin/lessons/_form.html.erb
+++ b/app/views/admin/lessons/_form.html.erb
@@ -17,7 +17,7 @@
     <label class="text-sm" for="description">Description</label>
     <%= form.rich_text_area :description, class: "rounded", id: "description", placeholder: "Lesson description" %>
   </div>
-  <div class="flex flex-col mt-4">
+  <div class="flex flex-col items-start mt-4">
     <label class="text-sm" for="paid">Paid</label>
     <%= form.check_box :paid, class: "rounded", id: "paid" %>
   </div>


### PR DESCRIPTION
## Summary
- Adds `has_rich_text :description` to the Lesson model so Action Text properly handles lesson descriptions
- Fixes the paid checkbox alignment in the admin lesson form by adding `items-start` to the flex container

Closes #45

## Test plan
- [ ] Verify lesson description renders as rich text in views
- [ ] Verify the paid checkbox is properly aligned in the lesson form
- [ ] Create/edit a lesson and confirm the rich text editor works correctly
