### PR TITLE
Enable view lessons link in course card

### DIFF
--- a/app/views/admin/courses/_course.html.erb
+++ b/app/views/admin/courses/_course.html.erb
@@ -7,6 +7,6 @@
   <div class="px-4 py-4">
     <div class="font-bold text-xl mb-6"><%= course.title %></div>
     <%= link_to "Edit Course", edit_admin_course_path(course), class: "bg-amaranth-500 hover:bg-amaranth-700 text-white-50 font-bold py-2 px-4 rounded" %>
-    <%#= link_to "View Lessons", admin_course_lessons_path(course), class: "bg-camelot-500 hover:bg-camelot-700 text-white-50 font-bold py-2 px-4 rounded" %>
+    <%= link_to "View Lessons", admin_course_lessons_path(course), class: "bg-camelot-500 hover:bg-camelot-700 text-white-50 font-bold py-2 px-4 rounded" %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Uncomments the "View Lessons" link in the admin course card partial, allowing admins to navigate directly to a course's lessons list

Closes #47

## Test plan
- [ ] Verify the "View Lessons" link appears on each course card in the admin panel
- [ ] Confirm clicking the link navigates to the correct course's lessons page

Made with [Cursor](https://cursor.com)